### PR TITLE
Fix issue where bottom of hook wasn't flat

### DIFF
--- a/bike_hanger/bike_hook.scad
+++ b/bike_hanger/bike_hook.scad
@@ -132,5 +132,5 @@ module bike_hook() {
 
 difference() {
     bike_hook();
-    translate([-(PLATE_HEIGHT / 2 + 5), 0, 0 ]) cube([10, 200, 200], center = true); 
+    translate([-(PLATE_HEIGHT / 2 + 5), 0, 0 ]) cube([10, 200, 300], center = true);
 }


### PR DESCRIPTION
When I changed the wheel width to 55 for my mountain bike the bottom of the hook was no longer flat, meaning it couldn't be printed on a flat surface: 

![image](https://user-images.githubusercontent.com/873212/92717822-ccfc9b80-f358-11ea-8a82-514d51d09ac9.png)

Changing the cube height fixed this. 